### PR TITLE
Bring Aries-common up to date and prepares for the Big Memory Kernels

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -26,8 +26,6 @@ TARGET_CPU_ABI := armeabi-v7a
 TARGET_CPU_ABI2 := armeabi
 TARGET_ARCH_VARIANT := armv7-a-neon
 ARCH_ARM_HAVE_TLS_REGISTER := true
-TARGET_GLOBAL_CFLAGS += -mtune=cortex-a8 -mfpu=neon -mfloat-abi=softfp
-TARGET_GLOBAL_CPPFLAGS += -mtune=cortex-a8 -mfpu=neon -mfloat-abi=softfp
 
 TARGET_NO_BOOTLOADER := true
 TARGET_NO_RADIOIMAGE := true

--- a/device_base.mk
+++ b/device_base.mk
@@ -50,6 +50,7 @@ PRODUCT_COPY_FILES := \
 # Init files
 PRODUCT_COPY_FILES += \
 	device/samsung/aries-common/init.aries.rc:root/init.aries.rc \
+	device/samsung/aries-common/init.aries.gps.rc:root/init.aries.gps.rc \
 	device/samsung/aries-common/init.aries.usb.rc:root/init.aries.usb.rc \
 	device/samsung/aries-common/init.aries.usb.rc:recovery/root/usb.rc \
 	device/samsung/aries-common/lpm.rc:root/lpm.rc \

--- a/init.aries.gps.rc
+++ b/init.aries.gps.rc
@@ -1,0 +1,18 @@
+#
+# init rc file for GPS: this is here to allow for devices
+# to provide their own GPS initialization code without
+# conflicting with the default GPS init. (i.e. Vibrant)
+#
+
+service gpsd /system/vendor/bin/gpsd -c /vendor/etc/gps.xml
+    class late_start
+    socket gps seqpacket 0660 gps system
+    user gps
+    group system inet
+
+on post-fs-data
+    # create data/gps for GPS demon
+    mkdir /data/gps 700 gps system
+    chown gps system /data/gps
+    chown gps root /sys/class/sec/gps/GPS_PWR_EN/value
+    chmod 660 /sys/class/sec/gps/GPS_PWR_EN/value

--- a/init.aries.rc
+++ b/init.aries.rc
@@ -1,4 +1,5 @@
 import init.aries.usb.rc
+import init.aries.gps.rc
 
 on init
     loglevel 9
@@ -88,12 +89,6 @@ on post-fs-data
     # setup datadata
     exec /sbin/setupdatadata.sh
 
-    # create data/gps for GPS demon
-    mkdir /data/gps 700 gps system
-    chown gps system /data/gps
-    chown gps root /sys/class/sec/gps/GPS_PWR_EN/value
-    chmod 660 /sys/class/sec/gps/GPS_PWR_EN/value
-
     # wi-fi
     mkdir /data/misc/wifi/sockets 0770 wifi wifi
     mkdir /data/misc/dhcp 0770 dhcp dhcp
@@ -116,12 +111,6 @@ service pvrsrvinit /system/vendor/bin/pvrsrvinit
     user root
     group root
     oneshot
-
-service gpsd /system/vendor/bin/gpsd -c /vendor/etc/gps.xml
-    class late_start
-    socket gps seqpacket 0660 gps system
-    user gps
-    group system inet
 
 service wpa_supplicant /system/bin/wpa_supplicant \
 		-Dnl80211 -iwlan0 -puse_p2p_group_interface=1 -e/data/misc/wifi/entropy.bin

--- a/libaudio/AudioHardware.cpp
+++ b/libaudio/AudioHardware.cpp
@@ -387,8 +387,8 @@ status_t AudioHardware::setMode(int mode)
     status = AudioHardwareBase::setMode(mode);
     LOGV("setMode() : new %d, old %d", mMode, prevMode);
     if (status == NO_ERROR) {
-        // activate call clock in radio when entering in call or ringtone mode
-        if (prevMode == AudioSystem::MODE_NORMAL)
+        // activate call clock in radio when entering in call mode
+        if (mMode == AudioSystem::MODE_IN_CALL)
         {
             if ((!mActivatedCP) && (mSecRilLibHandle) && (connectRILDIfRequired() == OK)) {
                 setCallClockSync(mRilClient, SOUND_CLOCK_START);

--- a/libaudio/AudioHardware.h
+++ b/libaudio/AudioHardware.h
@@ -86,6 +86,7 @@ public:
     static const char *inputPathNameDefault;
     static const char *inputPathNameCamcorder;
     static const char *inputPathNameVoiceRecognition;
+    static const char *inputPathNameVoiceCommunication;
 
     AudioHardware();
     virtual ~AudioHardware();

--- a/libcamera/SecCamera.cpp
+++ b/libcamera/SecCamera.cpp
@@ -974,6 +974,14 @@ int SecCamera::stopRecord(void)
     if (m_camera_id == CAMERA_ID_BACK) {
         ret = fimc_v4l2_s_ctrl(m_cam_fd, V4L2_CID_CAMERA_CAF_START_STOP, 0);
         CHECK(ret);
+
+        // Need to switch focus mode so that the camera can focus properly
+        // after using caf.
+        // Note: This bug is not affected when the original mode is macro
+        //       so we can safely use that as a mode to switch to.
+        int orig_mode = m_params->focus_mode;
+        setFocusMode(FOCUS_MODE_MACRO);
+        setFocusMode(orig_mode);
     }
 
     m_flag_record_start = 0;

--- a/libsensors/CompassSensor.cpp
+++ b/libsensors/CompassSensor.cpp
@@ -21,7 +21,6 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <sys/select.h>
-#include <cutils/properties.h>
 #include <cutils/log.h>
 
 
@@ -89,12 +88,6 @@ int CompassSensor::enable(int32_t, int en) {
             err = write(fd, buf, sizeof(buf));
             close(fd);
             mEnabled = flags;
-
-            /* Since the migration to 3.0 kernel, orientationd doesn't poll
-             * the enabled state properly, so start it when it's enabled and
-             * stop it when we're done using it.
-             */
-            property_set(mEnabled ? "ctl.start" : "ctl.stop", "orientationd");
             return 0;
         }
         return -1;        

--- a/libsensors/OrientationSensor.cpp
+++ b/libsensors/OrientationSensor.cpp
@@ -21,6 +21,7 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <sys/select.h>
+#include <cutils/properties.h>
 #include <cutils/log.h>
 
 
@@ -85,6 +86,12 @@ int OrientationSensor::enable(int32_t, int en) {
             close(fd);
             mEnabled = flags;
             //setInitialState();
+
+            /* Since the migration to 3.0 kernel, orientationd doesn't poll
+             * the enabled state properly, so start it when it's enabled and
+             * stop it when we're done using it.
+             */
+            property_set(mEnabled ? "ctl.start" : "ctl.stop", "orientationd");
             return 0;
         }
         return -1;        

--- a/overlay/packages/apps/Camera/res/values/config.xml
+++ b/overlay/packages/apps/Camera/res/values/config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds. -->
+<resources>
+    <!-- The camera removes the focus modes by default when touch-to-focus
+         exists. Use this option to change that behavior -->
+    <bool name="wantsFocusModes">true</bool>
+</resources>
+

--- a/recovery.rc
+++ b/recovery.rc
@@ -273,8 +273,10 @@ service adbd /sbin/adbd
     disabled
 
 # Always start adbd on userdebug and eng builds
+# In recovery, always run adbd as root.
 on property:ro.debuggable=1
     setprop sys.usb.config mass_storage,adb
+    setprop service.adb.root 1
 
 # Restart adbd so it can run as root
 on property:service.adb.root=1

--- a/releasetools/aries_edify_generator.py
+++ b/releasetools/aries_edify_generator.py
@@ -56,6 +56,9 @@ class EdifyGenerator(edify_generator.EdifyGenerator):
     def RunBackup(self, command):
       edify_generator.EdifyGenerator.RunBackup(self, command)
 
+    def RunConfig(self, command):
+      edify_generator.EdifyGenerator.RunConfig(self, command)
+
     def WriteBMLoverMTD(self, partition, partition_start_block, reservoirpartition, reservoir_start_block, image):
       """Write the given package file into the given partition."""
 

--- a/releasetools/aries_ota_from_target_files
+++ b/releasetools/aries_ota_from_target_files
@@ -103,6 +103,13 @@ def WriteFullOTAPackage(input_zip, output_zip):
   script.ShowProgress(0.15, 5)
   Item.Get("system").SetPermissions(script)
 
+  if OPTIONS.backuptool:
+    script.ShowProgress(0.2, 10)
+    script.RunBackup("restore")
+
+  if OPTIONS.modelidcfg:
+    script.RunConfig("")
+
   CopyBootFiles(input_zip, output_zip)
   CopyBMLoverMTD(output_zip)
 

--- a/sec_mm/sec_omx/sec_codecs/video/mfc_c110/include/SsbSipMfcApi.h
+++ b/sec_mm/sec_omx/sec_codecs/video/mfc_c110/include/SsbSipMfcApi.h
@@ -23,7 +23,7 @@
 #define MAX_DECODER_INPUT_BUFFER_SIZE  (1024 * 3072)
 #define MAX_ENCODER_OUTPUT_BUFFER_SIZE (1024 * 3072)
 
-#define MMAP_BUFFER_SIZE_MMAP          (62*1024*1024)
+#define MMAP_BUFFER_SIZE_MMAP          (20*1024*1024)
 
 #define S5PC110_MFC_DEV_NAME           "/dev/s3c-mfc"
 


### PR DESCRIPTION
Samsung dedicated memory to the kernel for many thing one of which is video buffering. Lucky for us they allocated way to much. By reducing the buffer size we can reduce the amount of RAM required to let it function by about 47MB. The kernels are coming from there respective device maintainers.
